### PR TITLE
fix timeout on getting empty chats, fix is_contact to allow adding users to chats to work

### DIFF
--- a/app/controllers/chat.server.controllers.js
+++ b/app/controllers/chat.server.controllers.js
@@ -74,7 +74,6 @@ const get_single_chat = (req, res) => {
                 }
 
                 log.warn(`chat.controller.get_single_chat: ${JSON.stringify(err)}`);
-                console.log("HERE")
                 return res.sendStatus(500); 
             }
 

--- a/app/models/chat.server.models.js
+++ b/app/models/chat.server.models.js
@@ -332,6 +332,7 @@ const get_all_chats = (user_id, done) => {
         (err) => {
             if(err) return done(err, null);
             if(errors.length > 0) return done(errors, null)
+            if (chats.length === 0) return done(null, [])
 
             let counter = 0;
 

--- a/app/models/contact.server.models.js
+++ b/app/models/contact.server.models.js
@@ -110,9 +110,9 @@ const is_contact = (user_id, contact_id, done) => {
         return done(true)
     }
 
-    let query = "SELECT * FROM whatsthat_user_contacts WHERE user_id = ? AND contact_id = ?"
+    let query = "SELECT * FROM whatsthat_user_contacts WHERE (user_id = ? AND contact_id = ?) OR (user_id = ? AND contact_id = ?)"
 
-    db.get(query, [user_id, contact_id], function(err, row){
+    db.get(query, [user_id, contact_id, contact_id, user_id], function(err, row){
         if(err) {
             return done(err, null)
         }


### PR DESCRIPTION
Missed a check for empty chat array which caused the request to timeout instead of responding. 
get_contacts was also inconsistent with is_contact which caused adding users to chats to break if A added B but B tries to add A to a chat (since the check was 1 way)